### PR TITLE
Add alert rules for MegaRAID controller.

### DIFF
--- a/src/prometheus_alert_rules/mega_raid.yaml
+++ b/src/prometheus_alert_rules/mega_raid.yaml
@@ -1,0 +1,39 @@
+groups:
+- name: MegaRAID
+  rules:
+
+  - alert: StorcliCommandFailed
+    expr: storcli_command_success == 0
+    for: 0m
+    labels:
+      severity: critical
+    annotations:
+      summary: Failed to run storcli. (instance {{ $labels.instance }})
+      description: |
+        Failed to get MegaRAID controller information using storcli.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
+
+  - alert: MegaRAIDControllerNotFound
+    expr: (megaraid_controllers == 0) and on (instance) (storcli_command_success == 1)
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      summary: MegaRAID controller not found. (instance {{ $labels.instance }})
+      description: |
+        Cannot found MegaRAID controller on this host machine.
+          NUMBER_OF_CONTROLLERS = {{ $value }}
+          LABELS = {{ $labels }}
+
+  - alert: MegaRAIDVirtualDriveNotOptimal
+    expr: (megaraid_virtual_drive_state{state != "Optl"} == 1) and on (instance) (storcli_command_success == 1)
+    for: 0m
+    labels:
+      severity: critical
+    annotations:
+      summary: MegaRAID virtual drives are not in optimal state. (instance {{ $labels.instance }})
+      description: |
+        MegaRAID virtual drives are not in optimal state. Please check the if the virtual drives are working as expected.
+          STATE = {{ $labels.state }}
+          LABELS = {{ $labels }}

--- a/tests/unit/test_alert_rules/test_mega_raid.yaml
+++ b/tests/unit/test_alert_rules/test_mega_raid.yaml
@@ -1,0 +1,75 @@
+rule_files:
+  - ../../../src/prometheus_alert_rules/mega_raid.yaml
+
+evaluation_interval: 1m
+
+tests:
+
+  - interval: 1m
+    input_series:
+      - series: 'storcli_command_success{instance="ubuntu-0"}'
+        values: '0x15' # error
+
+      - series: 'storcli_command_success{instance="ubuntu-1"}'
+        values: '1x15'
+      - series: 'megaraid_controllers{instance="ubuntu-1", hostname="ubuntu-1"}'
+        values: '0x15' # error
+      - series: 'megaraid_virtual_drive_state{instance="ubuntu-1", controller_id="0", virtual_drive_id="239", state="Optl"}'
+        values: '1x15' # okay
+      - series: 'megaraid_virtual_drive_state{instance="ubuntu-1", controller_id="0", virtual_drive_id="239", state="Dgrd"}'
+        values: '0x15' # okay
+
+      - series: 'storcli_command_success{instance="ubuntu-2"}'
+        values: '1x15'
+      - series: 'megaraid_controllers{instance="ubuntu-2", hostname="ubuntu-2"}'
+        values: '1x15' # okay
+      - series: 'megaraid_virtual_drive_state{instance="ubuntu-2", controller_id="0", virtual_drive_id="239", state="Optl"}'
+        values: '0x15' # error
+      - series: 'megaraid_virtual_drive_state{instance="ubuntu-2", controller_id="0", virtual_drive_id="239", state="Dgrd"}'
+        values: '1x15' # okay
+
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: StorcliCommandFailed
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: ubuntu-0
+            exp_annotations:
+              summary: Failed to run storcli. (instance ubuntu-0)
+              description: |
+                Failed to get MegaRAID controller information using storcli.
+                  VALUE = 0
+                  LABELS = map[__name__:storcli_command_success instance:ubuntu-0]
+
+
+      - eval_time: 0m
+        alertname: MegaRAIDControllerNotFound
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: ubuntu-1
+              hostname: ubuntu-1
+            exp_annotations:
+              summary: MegaRAID controller not found. (instance ubuntu-1)
+              description: |
+                Cannot found MegaRAID controller on this host machine.
+                  NUMBER_OF_CONTROLLERS = 0
+                  LABELS = map[__name__:megaraid_controllers hostname:ubuntu-1 instance:ubuntu-1]
+
+
+      - eval_time: 0m
+        alertname: MegaRAIDVirtualDriveNotOptimal
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: ubuntu-2
+              controller_id: 0
+              virtual_drive_id: 239
+              state: Dgrd
+            exp_annotations:
+              summary: MegaRAID virtual drives are not in optimal state. (instance ubuntu-2)
+              description: |
+                MegaRAID virtual drives are not in optimal state. Please check the if the virtual drives are working as expected.
+                  STATE = Dgrd
+                  LABELS = map[__name__:megaraid_virtual_drive_state controller_id:0 instance:ubuntu-2 state:Dgrd virtual_drive_id:239]


### PR DESCRIPTION
Add the following alert rules for MegaRAID controller.

- StorcliCommandFailed
- MegaRAIDControllerNotFound
- MegaRAIDVirtualDriveNotOptimal

Tested with `promtool`

```yaml
rule_files:
  - ../../../src/prometheus_alert_rules/mega_raid.yaml

evaluation_interval: 1m

tests:

  - interval: 1m
    input_series:
      - series: 'storcli_command_success{instance="ubuntu-0"}'
        values: '0x15' # error

      - series: 'storcli_command_success{instance="ubuntu-1"}'
        values: '1x15'
      - series: 'megaraid_controllers{instance="ubuntu-1", hostname="ubuntu-1"}'
        values: '0x15' # error
      - series: 'megaraid_virtual_drive_state{instance="ubuntu-1", controller_id="0", virtual_drive_id="239", state="Optl"}'
        values: '1x15' # okay
      - series: 'megaraid_virtual_drive_state{instance="ubuntu-1", controller_id="0", virtual_drive_id="239", state="Dgrd"}'
        values: '0x15' # okay

      - series: 'storcli_command_success{instance="ubuntu-2"}'
        values: '1x15'
      - series: 'megaraid_controllers{instance="ubuntu-2", hostname="ubuntu-2"}'
        values: '1x15' # okay
      - series: 'megaraid_virtual_drive_state{instance="ubuntu-2", controller_id="0", virtual_drive_id="239", state="Optl"}'
        values: '0x15' # error
      - series: 'megaraid_virtual_drive_state{instance="ubuntu-2", controller_id="0", virtual_drive_id="239", state="Dgrd"}'
        values: '1x15' # okay

    alert_rule_test:
      - eval_time: 0m
        alertname: StorcliCommandFailed
        exp_alerts:
          - exp_labels:
              severity: critical
              instance: ubuntu-0
            exp_annotations:
              summary: Failed to run storcli. (instance ubuntu-0)
              description: |
                Failed to get MegaRAID controller information using storcli.
                  VALUE = 0
                  LABELS = map[__name__:storcli_command_success instance:ubuntu-0]


      - eval_time: 0m
        alertname: MegaRAIDControllerNotFound
        exp_alerts:
          - exp_labels:
              severity: warning
              instance: ubuntu-1
              hostname: ubuntu-1
            exp_annotations:
              summary: MegaRAID controller not found. (instance ubuntu-1)
              description: |
                Cannot found MegaRAID controller on this host machine.
                  NUMBER_OF_CONTROLLERS = 0
                  LABELS = map[__name__:megaraid_controllers hostname:ubuntu-1 instance:ubuntu-1]


      - eval_time: 0m
        alertname: MegaRAIDVirtualDriveNotOptimal
        exp_alerts:
          - exp_labels:
              severity: critical
              instance: ubuntu-2
              controller_id: 0
              virtual_drive_id: 239
              state: Dgrd
            exp_annotations:
              summary: MegaRAID virtual drives are not in optimal state. (instance ubuntu-2)
              description: |
                MegaRAID virtual drives are not in optimal state. Please check the if the virtual drives are working as expected.
                  STATE = Dgrd
                  LABELS = map[__name__:megaraid_virtual_drive_state controller_id:0 instance:ubuntu-2 state:Dgrd virtual_drive_id:239]
```
