### PR TITLE
build(pydantic): Pin pydantic under version 2

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -191,7 +191,7 @@ LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
 LIBPATCH = 3
 
-PYDEPS = ["cosl", "pydantic"]
+PYDEPS = ["cosl", "pydantic < 2.0"]
 
 DEFAULT_RELATION_NAME = "cos-agent"
 DEFAULT_PEER_RELATION_NAME = "peers"


### PR DESCRIPTION
The pydantic 2 migration is not available for cos_agent.
We will migrate to v2 after cos_agent support it.